### PR TITLE
def was_attached?を削除

### DIFF
--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -3,13 +3,8 @@ class Prototype < ApplicationRecord
   belongs_to :user
   has_one_attached :image
 
-
   validates :title, presence: true
   validates :catch_copy, presence: true
-  validates :concept, presence: true, unless: :was_attached?
+  validates :concept, presence: true
 
-  def was_attached?
-    self.image.attached?
-  end
-  
 end


### PR DESCRIPTION
unless: :was_attached?

  def was_attached?
    self.image.attached?
  end

の記述を削除し、テキストがなくても投稿できてしまう不具合を修正しました